### PR TITLE
Fix white modals on answers.

### DIFF
--- a/quora-dark.css
+++ b/quora-dark.css
@@ -209,5 +209,15 @@
   .quote_hover_menu {
     /*[[hide-popup]]*/ display: none !important;
   }
+  
+  /*** Make the popup answer's background transparent black. ***/
+  .modal_overlay.feed_desktop_modal {
+   background: rgba(0,0,0,0.9);
+  }
+  
+  /*** Make the answer hover colour a dark black one. ***/
+  .toggle_modal_inline.inline_modal_highlight:hover {
+   background-color: #050505;
+  }
 
 }


### PR DESCRIPTION
Fixed the white modals when hovering on answers and when opening an answer (in a modal).

---
## BEFORE:

![screenshot from 2016-06-26 17-33-11](https://cloud.githubusercontent.com/assets/10473142/16364776/c67be99e-3c0c-11e6-8c4b-cbacae4e6740.png)
![screenshot from 2016-06-26 17-33-16](https://cloud.githubusercontent.com/assets/10473142/16364775/c674d7ee-3c0c-11e6-957f-aba95c216c2b.png)

---
## AFTER:

![screenshot from 2016-06-26 17-31-56](https://cloud.githubusercontent.com/assets/10473142/16364778/d1fcd102-3c0c-11e6-9140-d8d1d4278678.png)
![screenshot from 2016-06-26 17-32-04](https://cloud.githubusercontent.com/assets/10473142/16364779/d20439c4-3c0c-11e6-81a4-41ea2cc0821f.png)
